### PR TITLE
SLURM Scaling Stability

### DIFF
--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -7,6 +7,9 @@
 
 - name: Turn on SLURM controller daemon
   service: name=flight-slurmctld state=restarted enabled=yes
+  tags:
+    - update
+    - remove
 
 - name: Reload SLURM configuration
   shell: "/opt/flight/opt/slurm/bin/scontrol reconfigure"

--- a/roles/slurm/tasks/controller.yml
+++ b/roles/slurm/tasks/controller.yml
@@ -7,6 +7,10 @@
 
 - name: Turn on SLURM controller daemon
   service: name=flight-slurmctld state=restarted enabled=yes
+
+- name: Reload SLURM configuration
+  shell: "/opt/flight/opt/slurm/bin/scontrol reconfigure"
   tags:
+    - never
     - update
     - remove

--- a/roles/slurm/tasks/daemon.yml
+++ b/roles/slurm/tasks/daemon.yml
@@ -7,8 +7,3 @@
 
 - name: Turn on SLURM exec daemon
   service: name=flight-slurmd state=restarted enabled=yes
-  when:
-    - not ansible_fqdn in remove_node
-  tags:
-    - update
-    - remove


### PR DESCRIPTION
Utilise the `scontrol reconfigure` command for reloading slurm.conf changes on compute nodes as restarting `flight-slurmd` may cause issues for running jobs (e.g. by interrupting the stepd process). 